### PR TITLE
Add ingress to panda web GUI reverse proxy

### DIFF
--- a/services/p46-panda-web-gui/values.yaml
+++ b/services/p46-panda-web-gui/values.yaml
@@ -18,6 +18,9 @@ nginx:
           proxy_set_header Host $host;
       }
     }
+  ingress:
+    enabled: true
+    hostName: p46-blueapi.diamond.ac.uk
   networkPolicy:
     enabled: false
   nodeSelector:


### PR DESCRIPTION
See helm chart settings to enable ingress: https://artifacthub.io/packages/helm/bitnami/nginx