### PR TITLE
delete internal ophyd-async plans

### DIFF
--- a/services/p46-blueapi/values.yaml
+++ b/services/p46-blueapi/values.yaml
@@ -44,8 +44,8 @@ blueapi:
         module: htss_rig_bluesky.plans
       - kind: planFunctions
         module: dodal.plans
-      - kind: planFunctions
-        module: ophyd_async.plan_stubs
+      # - kind: planFunctions
+      #   module: ophyd_async.plan_stubs
       events:
         broadcast_status_events: False
     stomp:

--- a/services/p46-blueapi/values.yaml
+++ b/services/p46-blueapi/values.yaml
@@ -44,8 +44,6 @@ blueapi:
         module: htss_rig_bluesky.plans
       - kind: planFunctions
         module: dodal.plans
-      # - kind: planFunctions
-      #   module: ophyd_async.plan_stubs
       events:
         broadcast_status_events: False
     stomp:


### PR DESCRIPTION
 pydantic.errors.PydanticInvalidForJsonSchema: Cannot generate a JsonSchema for core_schema.IsInstanceSchema (<class 'ophyd_async.core._settings.Settings'>)

For further information visit https://errors.pydantic.dev/2.10/u/invalid-for-json-schema