### PR TITLE
ci: Set Renovate to automerge changes that should not require intervention

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,12 @@
       "matchSourceUrls": [
         "https://github.com/epics-containers/ec-helm-charts"
       ]
+    },
+    {
+      "description": ["automerge non-breaking changes for versions >=1.0.0"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Fixes #35

Configures Renovate to automate all merges that are:
- for versions >=1.0.0
- minor or patch versions

This will include:
- The Copier template, which will include CI and the ec-helm-chart versions regardless of whether they are major changes
- IOC containers, ~~but these will not be reflected until there has been a release made and the deployment repository re-pointed to those changes: this means that when a new release is to be made, there may be several changes stacked together which makes isolating problematic changes may be harder~~ IOCs now also target main of the services repository
- Minor github action updates which are seperate from the copier template- these can be disabled by adding them to the changes managed by the copier template update, or left as a canary for those changes?
- DAQ Helm charts, excluding the NeXus service, which Renovate is unable to see on these github repositories and so will need to be managed manually.