### PR TITLE
Revert "chore(deps): update rabbitmq docker tag to v16"

### DIFF
--- a/services/p46-rabbitmq/Chart.yaml
+++ b/services/p46-rabbitmq/Chart.yaml
@@ -12,5 +12,5 @@ type: application
 
 dependencies:
   - name: rabbitmq
-    version: 16.0.2
+    version: 11.16.2
     repository: oci://registry-1.docker.io/bitnamicharts


### PR DESCRIPTION
Reverts epics-containers/p46-services#34 as rabbitmq deployment cannot start pod on our infrastructure: requires further investigation