### PR TITLE
Make RabbitMQ IP address static

### DIFF
--- a/services/p46-rabbitmq/values.yaml
+++ b/services/p46-rabbitmq/values.yaml
@@ -17,6 +17,7 @@ rabbitmq:
       containerPort: 61613
   service:
     type: LoadBalancer
+    loadBalancerIP: 172.23.168.212
     extraPorts:
       - name: stomp
         port: 61613


### PR DESCRIPTION
Fix RabbitMQ IP address since it is not addressable with an ingress